### PR TITLE
edicion_propuesta_estado_pendiente_firma

### DIFF
--- a/_posts/2026-04-03_edicion_propuesta_estado_pendiente_firma.md
+++ b/_posts/2026-04-03_edicion_propuesta_estado_pendiente_firma.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: Edita la propuesta de un cliente desde el estado "Pendiente de firma".
+subtitle: Edita deudores, productos o montos en caso de ser necesario.
+gh-repo: /capitalexpress/capitalexpress.github.io
+gh-badge: [star, fork, follow]
+tags: [Admin, Super Admin, Riesgo]
+comments: false
+author: Catalina Pinilla.
+---
+
+### Factoring -  Solicitud de línea de crédito.
+
+Siempre quisiste poder editar directamente las condiciones de la propuesta (productos, deudores, montos, plazos y anticipos) cuando la solicitud está "Pendiente de firma",para ajustar el riesgo comercial en la última milla y aprobar la línea sin necesidad de devolver la solicitud a la etapa inicial ni reiniciar las firmas previas.
+Ahora es posible, además si la solicitud yas ha sido firmada por un integrante, aún así podrás realizar modificaciones sin necesidad de perder la firma ya  añadida.
+
+#### Aquí te mostramos cómo se ve:
+![edicion_propuesta_estado_pendiente_firma](https://cdn.capitalexpress.cl/img/edicion_propuesta_estado_pendiente_firma.png)

--- a/_posts/2026-04-03_edicion_propuesta_estado_pendiente_firma.md
+++ b/_posts/2026-04-03_edicion_propuesta_estado_pendiente_firma.md
@@ -11,7 +11,7 @@ author: Catalina Pinilla.
 
 ### Factoring -  Solicitud de línea de crédito.
 
-Siempre quisiste poder editar directamente las condiciones de la propuesta (productos, deudores, montos, plazos y anticipos) cuando la solicitud está "Pendiente de firma",para ajustar el riesgo comercial en la última milla y aprobar la línea sin necesidad de devolver la solicitud a la etapa inicial ni reiniciar las firmas previas.
+Siempre quisiste poder editar directamente las condiciones de la propuesta (productos, deudores, montos, plazos y anticipos) cuando la solicitud está "Pendiente de firma", para ajustar el riesgo comercial en la última milla y aprobar la línea sin necesidad de devolver la solicitud a la etapa inicial ni reiniciar las firmas previas.
 Ahora es posible, además si la solicitud yas ha sido firmada por un integrante, aún así podrás realizar modificaciones sin necesidad de perder la firma ya  añadida.
 
 #### Aquí te mostramos cómo se ve:


### PR DESCRIPTION
## Proof of completion
<img width="1917" height="1199" alt="image" src="https://github.com/user-attachments/assets/cf172484-4a19-41e2-831f-240a2e169e49" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a user guide for editing proposal conditions while a proposal is "Pendiente de firma". Users can edit products, debtors, amounts, terms, and advances without rolling back the workflow; edits remain effective even after signers complete approval. The guide includes illustrative imagery showing the edit experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->